### PR TITLE
feat: Implement user settings page in Tab 3

### DIFF
--- a/frontend/src/app/tab3/tab3.page.html
+++ b/frontend/src/app/tab3/tab3.page.html
@@ -1,7 +1,7 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
     <ion-title>
-      Tab 3
+      User Settings
     </ion-title>
   </ion-toolbar>
 </ion-header>
@@ -9,9 +9,13 @@
 <ion-content [fullscreen]="true">
   <ion-header collapse="condense">
     <ion-toolbar>
-      <ion-title size="large">Tab 3</ion-title>
+      <ion-title size="large">User Settings</ion-title>
     </ion-toolbar>
   </ion-header>
 
-  <app-explore-container name="Tab 3 page"></app-explore-container>
+  <ion-list>
+    <ion-item *ngFor="let option of settingsOptions" [button]="true" (click)="onSettingClick(option)">
+      {{ option }}
+    </ion-item>
+  </ion-list>
 </ion-content>

--- a/frontend/src/app/tab3/tab3.page.ts
+++ b/frontend/src/app/tab3/tab3.page.ts
@@ -9,5 +9,10 @@ import { ExploreContainerComponent } from '../explore-container/explore-containe
   imports: [IonHeader, IonToolbar, IonTitle, IonContent, ExploreContainerComponent],
 })
 export class Tab3Page {
+  public settingsOptions: string[] = ["Adjust Payments", "Adjust Portfolio", "Pause Contributions", "Set Beneficiaries"];
   constructor() {}
+
+  onSettingClick(setting: string) {
+    console.log('Clicked setting:', setting);
+  }
 }


### PR DESCRIPTION
This commit implements the user settings page in Tab 3 as per the issue requirements.

The changes include:
- Modified `frontend/src/app/tab3/tab3.page.ts` to include an array of settings options and a click handler method.
- Modified `frontend/src/app/tab3/tab3.page.html` to display a clickable list of these settings options and updated the page title to "User Settings".
- The click handler currently logs the selected setting to the console.