### PR TITLE
Refactor: Update survey options to use rounded chips

### DIFF
--- a/frontend/src/app/components/survey/survey.component.html
+++ b/frontend/src/app/components/survey/survey.component.html
@@ -19,7 +19,7 @@
       detail="false"
       [class.selected-option]="currentQuestion.answer === option.id"
     >
-      <ion-label class="ion-text-wrap">{{ option.text }}</ion-label>
+      <div class="survey-option-chip">{{ option.text }}</div>
       <ion-icon *ngIf="currentQuestion.answer === option.id" name="checkmark-circle" slot="end" color="primary"></ion-icon>
     </ion-item>
   </ion-list>

--- a/frontend/src/app/components/survey/survey.component.scss
+++ b/frontend/src/app/components/survey/survey.component.scss
@@ -20,7 +20,13 @@ ion-list {
   
   .selected-option {
     // border: 2px solid #007AFF; // Removed as checkmark will indicate selection
-    background-color: rgba(0, 122, 255, 0.05); // Very subtle tint for selection
+    // background-color: rgba(0, 122, 255, 0.05); // Very subtle tint for selection - REMOVED
+    // Visual indication is now on the chip itself.
+
+    .survey-option-chip {
+      background-color: #007AFF; // iOS primary blue
+      color: #ffffff; // White text for contrast
+    }
   }
   
   // Styling for the checkmark icon
@@ -39,4 +45,15 @@ ion-list {
     ion-toolbar {
       // Add styles if needed, e.g., background, padding
     }
+  }
+
+  .survey-option-chip {
+    background-color: #f0f0f0;
+    border-radius: 16px;
+    padding: 8px 16px;
+    margin: 4px 0;
+    display: inline-block;
+    color: #333;
+    width: 100%;
+    text-align: center;
   }


### PR DESCRIPTION
I replaced the list-item based display of survey response choices with individual, rounded chips to enhance visual appeal and align with standard iOS formatting.

- I modified `survey.component.html` to wrap option text in a `div.survey-option-chip`.
- I added styles in `survey.component.scss` for `.survey-option-chip` to define its appearance (background, border-radius, padding, margin).
- I updated the `.selected-option` style to change the background and text color of the selected chip, providing clear visual feedback.